### PR TITLE
Revised source code, bug fixes and new functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,33 @@ This is a Custom Component for Home-Assistant (https://home-assistant.io) that p
 
 You can read and control thermostat mode and presets, read current temperature and control the setpoint.
 
+Based on the standard behavior of the Toon the following two work modes are supported:
+- Heat:     Heat to a target temperature (schedule off)
+- Auto:     Follow the configured schedule as configured in your Toon (schedule on)
+
+The following five presets are supported
+- Away:     This will change the setpoint to what you have configured in your Toon for the away state
+- Home:     This will change the setpoint to what you have configured in your Toon for the home state
+- Comfort:  This will change the setpoint to what you have configured in your Toon for the comfort state
+- Sleep:    This will change the setpoint to what you have configured in your Toon for the sleep state
+
+(*) The above four presets can be used independent of the selected work mode.
+    -   When the Toon is set to "heat" mode the preset will change the setpoint to the setpoint
+        configured for the respective preset. It will keep that setpoint until you change it manually 
+        or switch to "auto" mode
+    -   When the Toon is set to "auto" mode the preset will change the setpoint to the setpoint configured
+        for the respective preset. However it will only change the setpoint temporatily until the schedule 
+        changes to the next programmed preset. 
+
+- Eco:      This will be used for the vacation mode the Toon offers. Regardless of the active work mode
+            the preset will change the setpoint to the setpoint configured for the "vacation" setting. It
+            will stay in this mode untill you change to one of the other four presets or chnage the work 
+            mode. So as long as the Toon is in eco (vacation) mode it will ensure the temperature does not
+            drop below the set setpoint.
+            
+(*) Please note that to use the "eco" (vacation) setpoint you will need to activate the vacation mode at 
+    least once on your Toon. If not the setpoint will use the lowest temperature (6 degrees celcius)
+
 NOTE: This component only works with rooted Toon devices.
 Toon thermostats are available in The Netherlands and Belgium.
 
@@ -37,6 +64,8 @@ climate:
     host: IP_ADDRESS
     port: 80
     scan_interval: 10
+    min_temp: 6.0
+    max_temp: 30.0
 ```
 
 Configuration variables:
@@ -46,7 +75,7 @@ Configuration variables:
 - **port** (*Optional*): Port used by your Toon. (default = 80, other used port numbers can be 10080 or 7080)
 - **scan_interval** (*Optional*): Number of seconds between polls. (default = 60)
 - **min_temp** (*Optional*): Minimal temperature you can set (default = 6.0)
-- **max_temp** (*Optional*): Maximal temperature you can set (default = 25.0)
+- **max_temp** (*Optional*): Maximal temperature you can set (default = 30.0)
 
 ## Screenshot
 

--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -1,22 +1,22 @@
-# =============================================================================
-# Climate support for Toon thermostat.
-# Only for the rooted version.
-#
-# configuration.yaml
-#
-# climate:
-#     - platform: toon_climate
-#         name: Toon Thermostat
-#         host: <IP_ADDRESS>
-#         port: 80
-#         scan_interval: 10
-#         min_temp: 6.0
-#         max_temp: 30.0
-#
-# More details:
-# - https://developers.home-assistant.io/docs/core/entity/climate/
-# - https://github.com/cyberjunky/home-assistant-toon_climate
-# =============================================================================
+"""
+Climate support for Toon thermostat.
+Only for the rooted version.
+
+configuration.yaml
+
+climate:
+    - platform: toon_climate
+        name: Toon Thermostat
+        host: <IP_ADDRESS>
+        port: 80
+        scan_interval: 10
+        min_temp: 6.0
+        max_temp: 30.0
+
+More details:
+- https://developers.home-assistant.io/docs/core/entity/climate/
+- https://github.com/cyberjunky/home-assistant-toon_climate
+"""
 
 import asyncio
 import logging
@@ -29,13 +29,13 @@ import voluptuous as vol
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
-    HVAC_MODE_HEAT,
     HVAC_MODE_AUTO,
+    HVAC_MODE_HEAT,
     PRESET_AWAY,
     PRESET_COMFORT,
+    PRESET_ECO,
     PRESET_HOME,
     PRESET_SLEEP,
-    PRESET_ECO,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -50,46 +50,46 @@ from homeassistant.helpers.aiohttp_client import async_get_clientsession
 import homeassistant.helpers.config_validation as cv
 
 try:
-    from homeassistant.components.climate import ClimateEntity, PLATFORM_SCHEMA
+    from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 except ImportError:
     from homeassistant.components.climate import (
-        ClimateDevice as ClimateEntity,
         PLATFORM_SCHEMA,
+        ClimateDevice as ClimateEntity,
     )
 
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
 
-# =============================================================================
-# Supported preset modes:
-#
-# PRESET_AWAY:      The device is in away mode
-# PRESET_HOME:      The device is in home mode
-# PRESET_COMFORT:   The device is in comfort mode
-# PRESET_SLEEP:     The device is in Sleep mode 
-# PRESET_ECO:       The device is runs a continuous energy savings mode. This
-#                   mode is used to activate the vacation mode
-# =============================================================================
-SUPPORT_PRESETS = [PRESET_AWAY, 
-                   PRESET_HOME, 
-                   PRESET_COMFORT, 
-                   PRESET_SLEEP, 
-                   PRESET_ECO]
+"""
+Supported preset modes:
 
-# =============================================================================
-# Supported hvac modes:
-#
-# - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)  
-# - HVAC_MODE_AUTO: Follow the configured schedule
-# =============================================================================
-SUPPORT_MODES = [HVAC_MODE_HEAT, 
-                 HVAC_MODE_AUTO]
+PRESET_AWAY:      The device is in away mode
+PRESET_HOME:      The device is in home mode
+PRESET_COMFORT:   The device is in comfort mode
+PRESET_SLEEP:     The device is in Sleep mode
+PRESET_ECO:       The device is runs a continuous energy savings mode. This
+                  mode is used to activate the vacation mode
+"""
+SUPPORT_PRESETS = [PRESET_AWAY, PRESET_HOME, PRESET_COMFORT, PRESET_SLEEP, PRESET_ECO]
+
+"""
+Supported hvac modes:
+
+- HVAC_MODE_HEAT: Heat to a target temperature (schedule off)
+- HVAC_MODE_AUTO: Follow the configured schedule
+"""
+SUPPORT_MODES = [HVAC_MODE_HEAT, HVAC_MODE_AUTO]
 
 DEFAULT_NAME = "Toon Thermostat"
 BASE_URL = "http://{0}:{1}{2}"
-DEFAULT_MIN_TEMP = 6.0  # Toon can be set to a minumum of 6 degrees celsius
-DEFAULT_MAX_TEMP = 30.0 # Toon can be set to a maximum of 30 degrees celsius
+
+"""
+Toon can be set to a minumum of 6 degrees celsius
+and a maximum of 30 degrees celsius
+"""
+DEFAULT_MIN_TEMP = 6.0
+DEFAULT_MAX_TEMP = 30.0
 CONF_MIN_TEMP = "min_temp"
 CONF_MAX_TEMP = "max_temp"
 
@@ -98,36 +98,35 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=80): cv.positive_int,
-        vol.Optional(CONF_MIN_TEMP, 
-                     default=DEFAULT_MIN_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_MAX_TEMP, 
-                     default=DEFAULT_MAX_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
     }
 )
 
 async def async_setup_platform(hass, config, add_devices, discovery_info=None):
-    # =====================================================================
-    # Setup the Toon thermostat
-    # =====================================================================
+    """
+    Setup the Toon thermostat
+    """
     session = async_get_clientsession(hass)
 
     add_devices([ThermostatDevice(session, config)], True)
 
-class ThermostatDevice(ClimateEntity):
-    # =====================================================================
-    # Representation of a Toon climate device
-    # =====================================================================
 
+class ThermostatDevice(ClimateEntity):
+    """
+    Representation of a Toon climate device
+    """
     def __init__(self, session, config) -> None:
-        # =================================================================
-        # Initialize the Toon climate device
-        # =================================================================
+        """
+        Initialize the Toon climate device
+        """
         self._session = session
         self._name = config.get(CONF_NAME)
         self._host = config.get(CONF_HOST)
         self._port = config.get(CONF_PORT)
         self._min_temp = config.get(CONF_MIN_TEMP)
         self._max_temp = config.get(CONF_MAX_TEMP)
+
         self._data = None
         self._active_state = None
         self._burner_info = None
@@ -138,13 +137,13 @@ class ThermostatDevice(ClimateEntity):
         self._program_state = None
 
     @staticmethod
-    async def do_api_request(self, url):
-        # =================================================================
-        # Do an API request
-        # =================================================================
+    async def do_api_request(session, url):
+        """
+        Do an API request
+        """
         try:
             with async_timeout.timeout(5):
-                response = await self._session.get(
+                response = await session.get(
                     url, headers={"Accept-Encoding": "identity"}
                 )
         except aiohttp.ClientError:
@@ -167,19 +166,19 @@ class ThermostatDevice(ClimateEntity):
 
     @property
     def should_poll(self):
-        # =================================================================
-        # Polling needed for thermostat
-        # =================================================================
+        """
+        Polling needed for thermostat
+        """
         return True
 
     async def async_update(self) -> None:
-        # =================================================================
-        # Update local data with thermostat data
-        # =================================================================
+        """
+        Update local data with thermostat data
+        """
         self._data = await self.do_api_request(
-            self,
+            self._session,
             BASE_URL.format(
-                self._host, self._port, 
+                self._host, self._port,
                 "/happ_thermstat?action=getThermostatInfo"
             ),
         )
@@ -192,67 +191,67 @@ class ThermostatDevice(ClimateEntity):
             self._current_temperature = int(self._data["currentTemp"]) / 100
             self._ot_comm_error = int(self._data["otCommError"])
             self._program_state = int(self._data["programState"])
-                
+
     @property
     def supported_features(self) -> int:
-        # =================================================================
-        # Return the list of supported features
-        # =================================================================
+        """
+        Return the list of supported features
+        """
         return SUPPORT_FLAGS
 
     @property
     def name(self) -> str:
-        # =================================================================
-        # Return the name of the thermostat
-        # =================================================================
+        """
+        Return the name of the thermostat
+        """
         return self._name
 
     @property
     def temperature_unit(self) -> str:
-        # =================================================================
-        # Return the unit of measurement (Celcius bt default)
-        # =================================================================
+        """
+        Return the unit of measurement (Celcius bt default)
+        """
         return TEMP_CELSIUS
 
     @property
     def min_temp(self) -> float:
-        # =================================================================
-        # Return the minimum temperature
-        # =================================================================
+        """
+        Return the minimum temperature
+        """
         return self._min_temp
 
     @property
     def max_temp(self) -> float:
-        # =================================================================
-        # Return the maximum temperature
-        # =================================================================
+        """
+        Return the maximum temperature
+        """
         return self._max_temp
 
     @property
     def current_temperature(self) -> Optional[float]:
-        # =================================================================
-        # Return the current temperature
-        # =================================================================
+        """
+        Return the current temperature
+        """
         return self._current_temperature
 
     @property
     def target_temperature(self) -> Optional[float]:
-        # =================================================================
-        # Return current target temperature (temp we try to reach)
-        # =================================================================
+        """
+        Return current target temperature (temp we try to reach)
+        """
         return self._current_setpoint
 
     async def async_set_temperature(self, **kwargs) -> None:
-        # =================================================================
-        # Set target temperature
-        # =================================================================
+        """
+        Set target temperature
+        """
         target_temperature = kwargs.get(ATTR_TEMPERATURE)
         if target_temperature is None:
             return
 
         value = target_temperature * 100
         self._data = await self.do_api_request(
-            self,
+            self._session,
             BASE_URL.format(
                 self._host, self._port,
                 "/happ_thermstat?action=setSetpoint"
@@ -268,152 +267,148 @@ class ThermostatDevice(ClimateEntity):
 
     @property
     def hvac_action(self) -> Optional[str]:
-        # =================================================================
-        # Return the current running hvac operation
-        #
-        # Toon burnerInfo values
-        # - 0: Burner is off
-        # - 1: Burner is on (heating for current setpoint)
-        # - 2: Burner is on (heating for generating warm water)
-        # - 3: Burner is on (preheating for next setpoint)
-        # =================================================================
+        """
+        Return the current running hvac operation
 
-        # When the burner is preheating or heating (not for warm water)
+        Toon burnerInfo values
+        - 0: Burner is off
+        - 1: Burner is on (heating for current setpoint)
+        - 2: Burner is on (heating for generating warm water)
+        - 3: Burner is on (preheating for next setpoint)
+        """
         if (self._burner_info == 1) or (self._burner_info == 3):
-            return CURRENT_HVAC_HEAT    # Report burner is active
-        return CURRENT_HVAC_IDLE  # Report burner is inactive
+            return CURRENT_HVAC_HEAT
+        return CURRENT_HVAC_IDLE
 
     @property
     def preset_modes(self) -> List[str]:
-        # =================================================================
-        # Return the list of available preset modes
-        # =================================================================
+        """
+        Return the list of available preset modes
+        """
         return SUPPORT_PRESETS
 
     @property
     def preset_mode(self) -> Optional[str]:
-        # =====================================================================
-        # Return the current preset mode
-        #
-        # Toon activeState values
-        # - 0: Comfort
-        # - 1: Home
-        # - 2: Sleep
-        # - 3: Away
-        # - 4: Vacation (not a default home assistant climate state)
-        #      instead we use the PRESET_ECO to be able to activate this
-        # =====================================================================
-        
-        if self._active_state == 0:
-            return PRESET_COMFORT
-        elif self._active_state == 1:
-            return PRESET_HOME
-        elif self._active_state == 2:
-            return PRESET_SLEEP
-        elif self._active_state == 3:
-            return PRESET_AWAY
-        elif self._active_state == 4:
-            return PRESET_ECO
-        else:
+        """
+        Return the current preset mode
+
+        Toon activeState values
+        - 0: Comfort
+        - 1: Home
+        - 2: Sleep
+        - 3: Away
+        - 4: Vacation (not a default home assistant climate state)
+             instead we use the PRESET_ECO to be able to activate this
+        """
+        presets = {
+            0: PRESET_COMFORT,
+            1: PRESET_HOME,
+            2: PRESET_SLEEP,
+            3: PRESET_AWAY,
+            4: PRESET_ECO,
+        }
+        try:
+            return presets[self._active_state]
+        except KeyError:
             return None
 
     async def async_set_preset_mode(self, preset_mode) -> None:
-        # =====================================================================
-        # Set new preset mode (comfort, home, sleep, away, eco)
-        #
-        # Toon programState values
-        # - 0: Programm mode is off (not automatically changing presets)
-        # - 1: Programm mode is on (automatically changing presets)
-        # - 2: Programm mode is on but setpoint/preset is changed until 
-        #      the next preset is automatically activated
-        # - 8: No official programm mode as according top the Toon API doc
-        #      this would be state 4. Testing it reveiled it only works when
-        #      we use an 8. This results in the programm state to return back
-        #      to it's original state when another preset is selected.
-        #
-        # Toon activeState values
-        # - 0: Comfort
-        # - 1: Home
-        # - 2: Sleep
-        # - 3: Away
-        # - 4: Vacation (not a default home assistant climate state)
-        #      instead we use the PRESET_ECO to be able to activate this
-        # =====================================================================
+        """
+        Set new preset mode (comfort, home, sleep, away, eco)
+
+        Toon programState values
+        - 0: Programm mode is off (not automatically changing presets)
+        - 1: Programm mode is on (automatically changing presets)
+        - 2: Programm mode is on but setpoint/preset is changed until
+             the next preset is automatically activated
+        - 8: No official programm mode as according top the Toon API doc
+             this would be state 4. Testing it reveiled it only works when
+             we use an 8. This results in the programm state to return back
+             to it's original state when another preset is selected.
+
+        Toon activeState values
+        - 0: Comfort
+        - 1: Home
+        - 2: Sleep
+        - 3: Away
+        - 4: Vacation (not a default home assistant climate state)
+             instead we use the PRESET_ECO to be able to activate this
+        """
         if preset_mode.lower() == PRESET_COMFORT:
-            scheme_temp = 0     # Comfort
-            scheme_state = 2    # Temporarily change preset
+            scheme_temp = 0
+            scheme_state = 2
         elif preset_mode.lower() == PRESET_HOME:
-            scheme_temp = 1     # Home
-            scheme_state = 2    # Temporarily change preset
+            scheme_temp = 1
+            scheme_state = 2
         elif preset_mode.lower() == PRESET_SLEEP:
-            scheme_temp = 2     # Sleep
-            scheme_state = 2    # Temporarily change preset
+            scheme_temp = 2
+            scheme_state = 2
         elif preset_mode.lower() == PRESET_AWAY:
-            scheme_temp = 3     # Away
-            scheme_state = 2    # Temporarily change preset
+            scheme_temp = 3
+            scheme_state = 2
         elif preset_mode.lower() == PRESET_ECO:
-            scheme_temp = 4     # Vacation mode
-            scheme_state = 8    # Change preset and retain programm state
+            scheme_temp = 4
+            scheme_state = 8
         else:
             scheme_temp = -1
-            scheme_state = 2    # Temporarily change preset
-		
+            scheme_state = 2
+
         self._data = await self.do_api_request(
-            self,
+            self._session,
             BASE_URL.format(
                 self._host, self._port,
                 "/happ_thermstat?action=changeSchemeState"
-                "&state=" + str(scheme_state) + 
+                "&state=" + str(scheme_state) +
                 "&temperatureState=" + str(scheme_temp),
             ),
         )
-        
+
         _LOGGER.debug(
-            "Set Toon preset mode to %s (value %s)", 
-            str(preset_mode.lower()), str(scheme_temp)
+            "Set Toon preset mode to %s (value %s)",
+            str(preset_mode.lower()),
+            str(scheme_temp),
         )
 
     @property
     def hvac_modes(self) -> List[str]:
-        # =================================================================
-        # Return the list of available hvac operation modes
-        # =================================================================
+        """
+        Return the list of available hvac operation modes
+        """
         return SUPPORT_MODES
 
     @property
     def hvac_mode(self) -> str:
-        # =================================================================
-        # Return the current operation mode
-        #
-        # Toon programState values
-        # - 0: Programm mode is off (not automatically changing presets)
-        # - 1: Programm mode is on (automatically changing presets)
-        # - 2: Programm mode is on but setpoint/preset is changed until 
-        #      the next preset is automatically activated
-        # - 8: No official programm mode as according to the Toon API doc
-        #      this would be state 4. This only seems to works when we
-        #      we use an 8. It will return the programm state to it's
-        #      original state when another preset is selected.
-        # =================================================================
+        """
+        Return the current operation mode
+
+        Toon programState values
+        - 0: Programm mode is off (not automatically changing presets)
+        - 1: Programm mode is on (automatically changing presets)
+        - 2: Programm mode is on but setpoint/preset is changed until
+             the next preset is automatically activated
+        - 8: No official programm mode as according to the Toon API doc
+             this would be state 4. This only seems to works when we
+             we use an 8. It will return the programm state to it's
+             original state when another preset is selected.
+        """
         if (self._program_state == 1) or (self._program_state == 2):
             return HVAC_MODE_AUTO
-        else:
-            return HVAC_MODE_HEAT
+
+        return HVAC_MODE_HEAT
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
-        # =====================================================================
-        # Set new target hvac mode
-        #
-        # Support modes:
-        # - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)  
-        # - HVAC_MODE_AUTO: Follow the configured schedule
-        # =====================================================================
+        """
+        Set new target hvac mode
 
+        Support modes:
+        - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)
+        - HVAC_MODE_AUTO: Follow the configured schedule
+        """
         _LOGGER.debug("Set Toon hvac mode to %s", str(hvac_mode))
 
         if hvac_mode == HVAC_MODE_HEAT:
             self._data = await self.do_api_request(
-                self,
+                self._session,
                 BASE_URL.format(
                     self._host, self._port,
                     "/happ_thermstat?action=changeSchemeState&state=0",
@@ -421,7 +416,7 @@ class ThermostatDevice(ClimateEntity):
             )
         elif hvac_mode == HVAC_MODE_AUTO:
             self._data = await self.do_api_request(
-                self,
+                self._session,
                 BASE_URL.format(
                     self._host, self._port,
                     "/happ_thermstat?action=changeSchemeState&state=1",
@@ -430,13 +425,14 @@ class ThermostatDevice(ClimateEntity):
 
     @property
     def device_state_attributes(self) -> Dict[str, Any]:
-        # =================================================================
-        # Return additional Toon Thermostat status details
-        #
-        # The information will be available in Home Assistant for reporting
-        # or automations based on teh provided information
-        # =================================================================
+        """
+        Return additional Toon Thermostat status details
+
+        The information will be available in Home Assistant for reporting
+        or automations based on teh provided information
+        """
         return {
             "burner_info": self._burner_info,
             "modulation_level": self._modulation_level,
         }
+

--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -1,16 +1,23 @@
-"""
-Climate support for Toon thermostat.
-Only for the rooted version.
+# =============================================================================
+# Climate support for Toon thermostat.
+# Only for the rooted version.
+#
+# configuration.yaml
+#
+# climate:
+#     - platform: toon_climate
+#         name: Toon Thermostat
+#         host: <IP_ADDRESS>
+#         port: 80
+#         scan_interval: 10
+#         min_temp: 6.0
+#         max_temp: 30.0
+#
+# More details:
+# - https://developers.home-assistant.io/docs/core/entity/climate/
+# - https://github.com/cyberjunky/home-assistant-toon_climate
+# =============================================================================
 
-configuration.yaml
-
-climate:
-    - platform: toon_climate
-        name: Toon Thermostat
-        host: <IP_ADDRESS>
-        port: 80
-        scan_interval: 10
-"""
 import asyncio
 import logging
 from typing import Any, Dict, List, Optional
@@ -22,13 +29,13 @@ import voluptuous as vol
 from homeassistant.components.climate.const import (
     CURRENT_HVAC_HEAT,
     CURRENT_HVAC_IDLE,
-    CURRENT_HVAC_OFF,
     HVAC_MODE_HEAT,
-    HVAC_MODE_OFF,
+    HVAC_MODE_AUTO,
     PRESET_AWAY,
     PRESET_COMFORT,
     PRESET_HOME,
     PRESET_SLEEP,
+    PRESET_ECO,
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
@@ -50,66 +57,91 @@ except ImportError:
         PLATFORM_SCHEMA,
     )
 
-
 _LOGGER = logging.getLogger(__name__)
 
 SUPPORT_FLAGS = SUPPORT_TARGET_TEMPERATURE | SUPPORT_PRESET_MODE
-SUPPORT_PRESETS = [PRESET_AWAY, PRESET_COMFORT, PRESET_HOME, PRESET_SLEEP]
-SUPPORT_MODES = [HVAC_MODE_HEAT, HVAC_MODE_OFF]
+
+# =============================================================================
+# Supported preset modes:
+#
+# PRESET_AWAY:      The device is in away mode
+# PRESET_HOME:      The device is in home mode
+# PRESET_COMFORT:   The device is in comfort mode
+# PRESET_SLEEP:     The device is in Sleep mode 
+# PRESET_ECO:       The device is runs a continuous energy savings mode. This
+#                   mode is used to activate the vacation mode
+# =============================================================================
+SUPPORT_PRESETS = [PRESET_AWAY, 
+                   PRESET_HOME, 
+                   PRESET_COMFORT, 
+                   PRESET_SLEEP, 
+                   PRESET_ECO]
+
+# =============================================================================
+# Supported hvac modes:
+#
+# - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)  
+# - HVAC_MODE_AUTO: Follow the configured schedule
+# =============================================================================
+SUPPORT_MODES = [HVAC_MODE_HEAT, 
+                 HVAC_MODE_AUTO]
 
 DEFAULT_NAME = "Toon Thermostat"
-DEFAULT_MAX_TEMP = 30.0
-DEFAULT_MIN_TEMP = 6.0
 BASE_URL = "http://{0}:{1}{2}"
-CONF_MAX_TEMP = "max_temp"
+DEFAULT_MIN_TEMP = 6.0  # Toon can be set to a minumum of 6 degrees celsius
+DEFAULT_MAX_TEMP = 30.0 # Toon can be set to a maximum of 30 degrees celsius
 CONF_MIN_TEMP = "min_temp"
+CONF_MAX_TEMP = "max_temp"
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=80): cv.positive_int,
-        vol.Optional(CONF_MIN_TEMP, default=6.0): vol.Coerce(float),
-        vol.Optional(CONF_MAX_TEMP, default=25.0): vol.Coerce(float),
+        vol.Optional(CONF_MIN_TEMP, 
+                     default=DEFAULT_MIN_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_MAX_TEMP, 
+                     default=DEFAULT_MAX_TEMP): vol.Coerce(float),
     }
 )
 
-# pylint: disable=unused-argument
 async def async_setup_platform(hass, config, add_devices, discovery_info=None):
-    """Setup the Toon thermostat."""
+    # =====================================================================
+    # Setup the Toon thermostat
+    # =====================================================================
     session = async_get_clientsession(hass)
 
     add_devices([ThermostatDevice(session, config)], True)
 
-
-# pylint: disable=too-many-instance-attributes
-# pylint: disable=bad-staticmethod-argument
 class ThermostatDevice(ClimateEntity):
-    """Representation of a Toon climate device."""
+    # =====================================================================
+    # Representation of a Toon climate device
+    # =====================================================================
 
     def __init__(self, session, config) -> None:
-        """Initialize the Toon climate device."""
+        # =================================================================
+        # Initialize the Toon climate device
+        # =================================================================
         self._session = session
         self._name = config.get(CONF_NAME)
         self._host = config.get(CONF_HOST)
         self._port = config.get(CONF_PORT)
         self._min_temp = config.get(CONF_MIN_TEMP)
         self._max_temp = config.get(CONF_MAX_TEMP)
-
         self._data = None
-        self._current_temperature = None
-        self._target_temperature = None
-        self._heating = False
+        self._active_state = None
         self._burner_info = None
         self._modulation_level = None
+        self._current_setpoint = None
+        self._current_temperature = None
+        self._ot_comm_error = None
         self._program_state = None
-        self._hvac_mode = HVAC_MODE_HEAT
-        self._state = None
-        self._preset = None
 
     @staticmethod
     async def do_api_request(self, url):
-        """Do an API request."""
+        # =================================================================
+        # Do an API request
+        # =================================================================
         try:
             with async_timeout.timeout(5):
                 response = await self._session.get(
@@ -135,115 +167,85 @@ class ThermostatDevice(ClimateEntity):
 
     @property
     def should_poll(self):
-        """Polling needed for thermostat."""
+        # =================================================================
+        # Polling needed for thermostat
+        # =================================================================
         return True
 
     async def async_update(self) -> None:
-        """Update local data with thermostat data."""
+        # =================================================================
+        # Update local data with thermostat data
+        # =================================================================
         self._data = await self.do_api_request(
             self,
             BASE_URL.format(
-                self._host, self._port, "/happ_thermstat?action=getThermostatInfo"
+                self._host, self._port, 
+                "/happ_thermstat?action=getThermostatInfo"
             ),
         )
 
         if self._data:
-            self._current_temperature = int(self._data["currentTemp"]) / 100
-            self._target_temperature = int(self._data["currentSetpoint"]) / 100
-            self._program_state = int(self._data["programState"])
+            self._active_state = int(self._data["activeState"])
             self._burner_info = int(self._data["burnerInfo"])
             self._modulation_level = int(self._data["currentModulationLevel"])
-
-            state = int(self._data["activeState"])
-            if state == 0:
-                self._preset = PRESET_COMFORT
-            elif state == 1:
-                self._preset = PRESET_HOME
-            elif state == 2:
-                self._preset = PRESET_SLEEP
-            elif state == 3:
-                self._preset = PRESET_AWAY
-            else:
-                self._preset = None
-
-            self._heating = self._burner_info == 1
-
+            self._current_setpoint = int(self._data["currentSetpoint"]) / 100
+            self._current_temperature = int(self._data["currentTemp"]) / 100
+            self._ot_comm_error = int(self._data["otCommError"])
+            self._program_state = int(self._data["programState"])
+                
     @property
     def supported_features(self) -> int:
-        """Return the list of supported features."""
+        # =================================================================
+        # Return the list of supported features
+        # =================================================================
         return SUPPORT_FLAGS
 
     @property
     def name(self) -> str:
-        """Return the name of the thermostat."""
+        # =================================================================
+        # Return the name of the thermostat
+        # =================================================================
         return self._name
 
     @property
-    def device_state_attributes(self) -> Dict[str, Any]:
-        """Return the current state of the burner."""
-        return {
-            "burner_info": self._burner_info,
-            "modulation_level": self._modulation_level,
-        }
-
-    @property
     def temperature_unit(self) -> str:
-        """Return the unit of measurement."""
+        # =================================================================
+        # Return the unit of measurement (Celcius bt default)
+        # =================================================================
         return TEMP_CELSIUS
 
     @property
-    def current_temperature(self) -> Optional[float]:
-        """Return the current temperature."""
-        return self._current_temperature
-
-    @property
-    def target_temperature(self) -> Optional[float]:
-        """Return the temperature we try to reach."""
-        return self._target_temperature
-
-    @property
     def min_temp(self) -> float:
-        """Return the minimum temperature."""
+        # =================================================================
+        # Return the minimum temperature
+        # =================================================================
         return self._min_temp
 
     @property
     def max_temp(self) -> float:
-        """Return the maximum temperature."""
+        # =================================================================
+        # Return the maximum temperature
+        # =================================================================
         return self._max_temp
 
-    async def async_set_preset_mode(self, preset_mode) -> None:
-        """Set HVAC mode (comfort, home, sleep, away)."""
+    @property
+    def current_temperature(self) -> Optional[float]:
+        # =================================================================
+        # Return the current temperature
+        # =================================================================
+        return self._current_temperature
 
-        preset = preset_mode.lower()
-
-        if preset == "comfort":
-            state = 0
-        elif preset == "home":
-            state = 1
-        elif preset == "sleep":
-            state = 2
-        elif preset == "away":
-            state = 3
-        else:
-            state = -1
-
-        self._preset = preset
-
-        self._data = await self.do_api_request(
-            self,
-            BASE_URL.format(
-                self._host,
-                self._port,
-                "/happ_thermstat?action=changeSchemeState"
-                "&state=2&temperatureState=" + str(state),
-            ),
-        )
-        _LOGGER.debug(
-            "Set Toon preset mode to %s (value %s)", str(self._preset), str(state)
-        )
+    @property
+    def target_temperature(self) -> Optional[float]:
+        # =================================================================
+        # Return current target temperature (temp we try to reach)
+        # =================================================================
+        return self._current_setpoint
 
     async def async_set_temperature(self, **kwargs) -> None:
-        """Set target temperature."""
+        # =================================================================
+        # Set target temperature
+        # =================================================================
         target_temperature = kwargs.get(ATTR_TEMPERATURE)
         if target_temperature is None:
             return
@@ -252,9 +254,9 @@ class ThermostatDevice(ClimateEntity):
         self._data = await self.do_api_request(
             self,
             BASE_URL.format(
-                self._host,
-                self._port,
-                "/happ_thermstat?action=setSetpoint&Setpoint=" + str(value),
+                self._host, self._port,
+                "/happ_thermstat?action=setSetpoint"
+                "&Setpoint=" + str(value),
             ),
         )
         _LOGGER.debug(
@@ -262,61 +264,179 @@ class ThermostatDevice(ClimateEntity):
             str(target_temperature),
             str(value),
         )
-        self._target_temperature = target_temperature
-
-    @property
-    def hvac_mode(self) -> str:
-        """Return the current operation mode."""
-        return self._hvac_mode
-
-    @property
-    def hvac_modes(self) -> List[str]:
-        """Return the list of available hvac operation modes."""
-        return SUPPORT_MODES
+        self._current_setpoint = target_temperature
 
     @property
     def hvac_action(self) -> Optional[str]:
-        """Return the current running hvac operation."""
-        if self._heating:
-            return CURRENT_HVAC_HEAT
-        if self._program_state == 0:
-            return CURRENT_HVAC_OFF
+        # =================================================================
+        # Return the current running hvac operation
+        #
+        # Toon burnerInfo values
+        # - 0: Burner is off
+        # - 1: Burner is on (heating for current setpoint)
+        # - 2: Burner is on (heating for generating warm water)
+        # - 3: Burner is on (preheating for next setpoint)
+        # =================================================================
 
-        return CURRENT_HVAC_IDLE
-
-    @property
-    def preset_mode(self) -> Optional[str]:
-        """Return the current preset mode, e.g., home, away, temp."""
-        if self._preset is not None:
-            return self._preset.lower()
-        return None
+        # When the burner is preheating or heating (not for warm water)
+        if (self._burner_info == 1) or (self._burner_info == 3):
+            return CURRENT_HVAC_HEAT    # Report burner is active
+        return CURRENT_HVAC_IDLE  # Report burner is inactive
 
     @property
     def preset_modes(self) -> List[str]:
-        """List of available preset modes."""
+        # =================================================================
+        # Return the list of available preset modes
+        # =================================================================
         return SUPPORT_PRESETS
 
+    @property
+    def preset_mode(self) -> Optional[str]:
+        # =====================================================================
+        # Return the current preset mode
+        #
+        # Toon activeState values
+        # - 0: Comfort
+        # - 1: Home
+        # - 2: Sleep
+        # - 3: Away
+        # - 4: Vacation (not a default home assistant climate state)
+        #      instead we use the PRESET_ECO to be able to activate this
+        # =====================================================================
+        
+        if self._active_state == 0:
+            return PRESET_COMFORT
+        elif self._active_state == 1:
+            return PRESET_HOME
+        elif self._active_state == 2:
+            return PRESET_SLEEP
+        elif self._active_state == 3:
+            return PRESET_AWAY
+        elif self._active_state == 4:
+            return PRESET_ECO
+        else:
+            return None
+
+    async def async_set_preset_mode(self, preset_mode) -> None:
+        # =====================================================================
+        # Set new preset mode (comfort, home, sleep, away, eco)
+        #
+        # Toon programState values
+        # - 0: Programm mode is off (not automatically changing presets)
+        # - 1: Programm mode is on (automatically changing presets)
+        # - 2: Programm mode is on but setpoint/preset is changed until 
+        #      the next preset is automatically activated
+        # - 8: No official programm mode as according top the Toon API doc
+        #      this would be state 4. Testing it reveiled it only works when
+        #      we use an 8. This results in the programm state to return back
+        #      to it's original state when another preset is selected.
+        #
+        # Toon activeState values
+        # - 0: Comfort
+        # - 1: Home
+        # - 2: Sleep
+        # - 3: Away
+        # - 4: Vacation (not a default home assistant climate state)
+        #      instead we use the PRESET_ECO to be able to activate this
+        # =====================================================================
+        if preset_mode.lower() == PRESET_COMFORT:
+            scheme_temp = 0     # Comfort
+            scheme_state = 2    # Temporarily change preset
+        elif preset_mode.lower() == PRESET_HOME:
+            scheme_temp = 1     # Home
+            scheme_state = 2    # Temporarily change preset
+        elif preset_mode.lower() == PRESET_SLEEP:
+            scheme_temp = 2     # Sleep
+            scheme_state = 2    # Temporarily change preset
+        elif preset_mode.lower() == PRESET_AWAY:
+            scheme_temp = 3     # Away
+            scheme_state = 2    # Temporarily change preset
+        elif preset_mode.lower() == PRESET_ECO:
+            scheme_temp = 4     # Vacation mode
+            scheme_state = 8    # Change preset and retain programm state
+        else:
+            scheme_temp = -1
+            scheme_state = 2    # Temporarily change preset
+		
+        self._data = await self.do_api_request(
+            self,
+            BASE_URL.format(
+                self._host, self._port,
+                "/happ_thermstat?action=changeSchemeState"
+                "&state=" + str(scheme_state) + 
+                "&temperatureState=" + str(scheme_temp),
+            ),
+        )
+        
+        _LOGGER.debug(
+            "Set Toon preset mode to %s (value %s)", 
+            str(preset_mode.lower()), str(scheme_temp)
+        )
+
+    @property
+    def hvac_modes(self) -> List[str]:
+        # =================================================================
+        # Return the list of available hvac operation modes
+        # =================================================================
+        return SUPPORT_MODES
+
+    @property
+    def hvac_mode(self) -> str:
+        # =================================================================
+        # Return the current operation mode
+        #
+        # Toon programState values
+        # - 0: Programm mode is off (not automatically changing presets)
+        # - 1: Programm mode is on (automatically changing presets)
+        # - 2: Programm mode is on but setpoint/preset is changed until 
+        #      the next preset is automatically activated
+        # - 8: No official programm mode as according to the Toon API doc
+        #      this would be state 4. This only seems to works when we
+        #      we use an 8. It will return the programm state to it's
+        #      original state when another preset is selected.
+        # =================================================================
+        if (self._program_state == 1) or (self._program_state == 2):
+            return HVAC_MODE_AUTO
+        else:
+            return HVAC_MODE_HEAT
+
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
-        """Set new target hvac mode."""
+        # =====================================================================
+        # Set new target hvac mode
+        #
+        # Support modes:
+        # - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)  
+        # - HVAC_MODE_AUTO: Follow the configured schedule
+        # =====================================================================
+
         _LOGGER.debug("Set Toon hvac mode to %s", str(hvac_mode))
 
-        if hvac_mode == "off":
+        if hvac_mode == HVAC_MODE_HEAT:
             self._data = await self.do_api_request(
                 self,
                 BASE_URL.format(
-                    self._host,
-                    self._port,
+                    self._host, self._port,
                     "/happ_thermstat?action=changeSchemeState&state=0",
                 ),
             )
-            self._hvac_mode = HVAC_MODE_OFF
-        elif hvac_mode == "heat":
+        elif hvac_mode == HVAC_MODE_AUTO:
             self._data = await self.do_api_request(
                 self,
                 BASE_URL.format(
-                    self._host,
-                    self._port,
-                    "/happ_thermstat?action=changeSchemeState" "&state=1",
+                    self._host, self._port,
+                    "/happ_thermstat?action=changeSchemeState&state=1",
                 ),
             )
-            self._hvac_mode = HVAC_MODE_HEAT
+
+    @property
+    def device_state_attributes(self) -> Dict[str, Any]:
+        # =================================================================
+        # Return additional Toon Thermostat status details
+        #
+        # The information will be available in Home Assistant for reporting
+        # or automations based on teh provided information
+        # =================================================================
+        return {
+            "burner_info": self._burner_info,
+            "modulation_level": self._modulation_level,
+        }

--- a/info.md
+++ b/info.md
@@ -1,14 +1,56 @@
 [![hacs_badge](https://img.shields.io/badge/HACS-Default-orange.svg)](https://github.com/custom-components/hacs)  [![made-with-python](https://img.shields.io/badge/Made%20with-Python-1f425f.svg)](https://www.python.org/) [![Donate](https://img.shields.io/badge/Donate-PayPal-green.svg)](https://www.paypal.me/cyberjunkynl/)
 
+# Toon Climate Component
 This is a Custom Component for Home-Assistant (https://home-assistant.io) that provides a climate device for rooted Toon thermostats.
 
 You can read and control thermostat mode and presets, read current temperature and control the setpoint.
+
+Based on the standard behavior of the Toon the following two work modes are supported:
+- Heat:     Heat to a target temperature (schedule off)
+- Auto:     Follow the configured schedule as configured in your Toon (schedule on)
+
+The following five presets are supported
+- Away:     This will change the setpoint to what you have configured in your Toon for the away state
+- Home:     This will change the setpoint to what you have configured in your Toon for the home state
+- Comfort:  This will change the setpoint to what you have configured in your Toon for the comfort state
+- Sleep:    This will change the setpoint to what you have configured in your Toon for the sleep state
+
+(*) The above four presets can be used independent of the selected work mode.
+    -   When the Toon is set to "heat" mode the preset will change the setpoint to the setpoint
+        configured for the respective preset. It will keep that setpoint until you change it manually 
+        or switch to "auto" mode
+    -   When the Toon is set to "auto" mode the preset will change the setpoint to the setpoint configured
+        for the respective preset. However it will only change the setpoint temporatily until the schedule 
+        changes to the next programmed preset. 
+
+- Eco:      This will be used for the vacation mode the Toon offers. Regardless of the active work mode
+            the preset will change the setpoint to the setpoint configured for the "vacation" setting. It
+            will stay in this mode untill you change to one of the other four presets or chnage the work 
+            mode. So as long as the Toon is in eco (vacation) mode it will ensure the temperature does not
+            drop below the set setpoint.
+            
+(*) Please note that to use the "eco" (vacation) setpoint you will need to activate the vacation mode at 
+    least once on your Toon. If not the setpoint will use the lowest temperature (6 degrees celcius)
 
 NOTE: This component only works with rooted Toon devices.
 Toon thermostats are available in The Netherlands and Belgium.
 
 More information about rooting your Toon can be found here:
 [Eneco Toon as Domotica controller](http://www.domoticaforum.eu/viewforum.php?f=87)
+
+## Installation
+
+### HACS - Recommended
+- Have [HACS](https://hacs.xyz) installed, this will allow you to easily manage and track updates.
+- Search for 'Toon Climate'.
+- Click Install below the found integration.
+- Configure using the configuration instructions below.
+- Restart Home-Assistant.
+
+### Manual
+- Copy directory `custom_components/toon_climate` to your `<config dir>/custom_components` directory.
+- Configure with config below.
+- Restart Home-Assistant.
 
 ## Usage
 To use this component in your installation, add the following to your `configuration.yaml` file:
@@ -22,16 +64,18 @@ climate:
     host: IP_ADDRESS
     port: 80
     scan_interval: 10
+    min_temp: 6.0
+    max_temp: 30.0
 ```
 
 Configuration variables:
 
 - **name** (*Optional*): Name of the device. (default = 'Toon Thermostat')
 - **host** (*Required*): The IP address on which the Toon can be reached.
-- **port** (*Optional*): Port used by your Toon. (default = 80, other used port numbers can be 10080 or 7080))
+- **port** (*Optional*): Port used by your Toon. (default = 80, other used port numbers can be 10080 or 7080)
 - **scan_interval** (*Optional*): Number of seconds between polls. (default = 60)
 - **min_temp** (*Optional*): Minimal temperature you can set (default = 6.0)
-- **max_temp** (*Optional*): Maximal temperature you can set (default = 25.0)
+- **max_temp** (*Optional*): Maximal temperature you can set (default = 30.0)
 
 ## Screenshot
 
@@ -41,10 +85,12 @@ Toon with simple-thermostat in Lovelace
 
 ![alt text](https://github.com/cyberjunky/home-assistant-toon_climate/blob/master/screenshots/toon-simple.png?raw=true "Toon simple-thermostat Screenshot")
 
+Install Javascript from: https://github.com/nervetattoo/simple-thermostat
+
 Using this card:
 ```
    - type: 'custom:simple-thermostat'
-     entity: climate.toon
+     entity: climate.toon_thermostat
      control:
        - preset
 ```
@@ -67,6 +113,46 @@ sensor:
           {% endif %}
 ```
 
+If you want the room temperature in a badge do this:
+```yaml
+sensor:
+  - platform: template
+    sensors:
+      temperatuur_woonkamer:
+        friendly_name: "Temperatuur Woonkamer"
+        value_template: "{{ state_attr('climate.toon','current_temperature') }}"
+        unit_of_measurement: °C
+```
+
+If you have a Toon2 and want to gather the environment sensor data you can create REST sensors like this:
+```yaml
+sensor:
+  - platform: rest
+    name: Toon2 AirSensors
+    json_attributes:
+      - humidity
+      - tvoc
+      - eco2
+    value_template: '{{ value_json["temperature"] }}'
+    unit_of_measurement: "°C"
+    resource: http://192.168.2.106/tsc/sensors
+
+  - platform: template
+    sensors:
+      toon2_humidity:
+        friendly_name: "Humidity"
+        value_template: '{{ states.sensor.toon2_airsensors.attributes["humidity"] }}'
+        unit_of_measurement: "%"
+      toon2_tvoc:
+        friendly_name: "TVOC"
+        value_template: '{{ states.sensor.toon2_airsensors.attributes["tvoc"] }}'
+        unit_of_measurement: "ppm"
+      toon2_eco2:
+        friendly_name: "ECO2"
+        value_template: '{{ states.sensor.toon2_airsensors.attributes["eco2"] }}'
+        unit_of_measurement: "?"
+```
+          
 You can also control it with Google's assistant
 
 ![alt text](https://github.com/cyberjunky/home-assistant-toon_climate/blob/master/screenshots/toon-setpoint.png?raw=true "Toon Assistant Setpoint")


### PR DESCRIPTION
I love this custom climate component for the Toon and I decided to personally contribute to this project. Please see the overview of the changes I made to the code below:

Revised the code in “climate.py” to support “auto” (scheduled) and “heat” (manual) work mode.

Also added the support for the “eco” preset. Instead of a normal preset this “eco” preset will allow you to put the Toon in “vacation mode”. The latter means it will change the setpoint in the Toon to what has last been set in the Vacation mode the Toon offers. It will keep this setpoint until you change it to one of the other (standard) setpoints supported by the Toon or change the actual work mode.

Changed the code so it uses the actual config parameters for the min and max temp. The previous version of the code had the parameters but did not change them in the code.

Changed to code to correctly update the work mode status in Home Assistant when the work mode is changed manually on the Toon device. The previous version did not support this and the status of the climate object in Home Assistant got out of sync.

Cleaned up and re-ordered the code a bit and added additional comments in the code to explain a bit more what it does and what the meaning is of some of the settings.

As for some reason home assistant does not like the comment with the triple quotation marks when I added them in different areas of the code I replaced all the previous comments with teh triple quotation marks with inline comments using the pound sign instead. After that Home Assistant seemed to be very happy.

Updated the “README.mb” file the reflect the above.

I have tested the updated code as much as I can on my own "Toon 1" and it seems to works fine hence why I am happy to commit the changes. All changes either in home assistant or on the manually Toon are working well and in sync with the status on the Toon or in Home assistant.