### PR TITLE
Improved logging

### DIFF
--- a/info.md
+++ b/info.md
@@ -40,8 +40,16 @@ More information about rooting your Toon can be found here:
 
 ## Installation
 
-- Install this integration using HACS.
-- Configure using configuration instructions below.
+### HACS - Recommended
+- Have [HACS](https://hacs.xyz) installed, this will allow you to easily manage and track updates.
+- Search for 'Toon Climate'.
+- Click Install below the found integration.
+- Configure using the configuration instructions below.
+- Restart Home-Assistant.
+
+### Manual
+- Copy directory `custom_components/toon_climate` to your `<config dir>/custom_components` directory.
+- Configure with config below.
 - Restart Home-Assistant.
 
 ## Usage
@@ -224,14 +232,17 @@ sensor:
         friendly_name: "Humidity"
         value_template: '{{ states.sensor.toon2_airsensors.attributes["humidity"] }}'
         unit_of_measurement: "%"
+        icon_template: "mdi:water-percent"
       toon2_tvoc:
         friendly_name: "TVOC"
         value_template: '{{ states.sensor.toon2_airsensors.attributes["tvoc"] }}'
-        unit_of_measurement: "ppm"
+        unit_of_measurement: "ppb"
+        icon_template: "mdi:air-filter"
       toon2_eco2:
-        friendly_name: "ECO2"
+        friendly_name: "eCO2"
         value_template: '{{ states.sensor.toon2_airsensors.attributes["eco2"] }}'
-        unit_of_measurement: "?"
+        unit_of_measurement: "ppm"
+        icon_template: "mdi:molecule-co2"
 ```
 
 
@@ -258,6 +269,7 @@ You can also control the Toon device with Google's assistant.
 
 ![alt text](https://github.com/cyberjunky/home-assistant-toon_climate/blob/master/screenshots/toon-setpoint.png?raw=true "Toon Assistant Setpoint")
 ![alt text](https://github.com/cyberjunky/home-assistant-toon_climate/blob/master/screenshots/toon-eco-preset.png?raw=true "Toon Assistant ECO Preset")
+
 
 ## Debugging
 


### PR DESCRIPTION
Improved the logging as follows:

Changed the basic logging to log as info messages. Due to this messages with respect to standard requests will show in the logs when at least set to info level (default).

Added additional debug log details to provide messages with more detail about the request send to the Toon device. These messages will only be available when the log level for the Toon component is at least set to debug level.

Added the actual name for the respective Toon instance to the log messages. This way it is clear in the logs which instance of the Toon the log messages are related to. Especially usefull when more than one Toon instance is configured.  

Made sure the log will show the messages in the following order:

1. standard request message (info)
2. detailed request information (debug)
3. detailed response information (debug)

This way it is easy to understand from the logs what the result is for each individual request.