### PR TITLE
Input validation added

### DIFF
--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -74,8 +74,9 @@ PRESET_AWAY:      The device is in away mode
 PRESET_HOME:      The device is in home mode
 PRESET_COMFORT:   The device is in comfort mode
 PRESET_SLEEP:     The device is in Sleep mode
-PRESET_ECO:       The device is runs a continuous energy savings mode. This
-                  mode is used to activate the vacation mode
+PRESET_ECO:       The device runs in a continuous energy savings mode. If 
+                  configured as one of the supported presets this This mode
+                  can be used to activate the vacation mode
 """
 SUPPORT_PRESETS = [PRESET_AWAY, PRESET_HOME, PRESET_COMFORT, PRESET_SLEEP, PRESET_ECO]
 
@@ -84,7 +85,9 @@ Supported hvac modes:
 
 - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)
 - HVAC_MODE_AUTO: Follow the configured schedule
-- HVAC_MODE_OFF: This mode is used to activate the vacation mode
+- HVAC_MODE_OFF:  The device runs in a continuous energy savings mode. If 
+                  configured as one of the supported hvac modes this This mode
+                  can be used to activate the vacation mode
 """
 SUPPORT_MODES = [HVAC_MODE_HEAT, HVAC_MODE_AUTO]
 
@@ -92,8 +95,8 @@ DEFAULT_NAME = "Toon Thermostat"
 BASE_URL = "http://{0}:{1}{2}"
 
 """
-Toon can be set to a minumum of 6 degrees celsius
-and a maximum of 30 degrees celsius
+The Toon device can be set to a minumum of 6 degrees celsius and a maximum
+of 30 degrees celsius. The below min and max values should not be changed. 
 """
 DEFAULT_MIN_TEMP = 6.0
 DEFAULT_MAX_TEMP = 30.0
@@ -241,8 +244,7 @@ class ThermostatDevice(ClimateEntity):
                 self._hvac_mode = HVAC_MODE_AUTO
             else:
                 self._hvac_mode = None
-
-                
+   
     @property
     def supported_features(self) -> int:
         """
@@ -260,7 +262,7 @@ class ThermostatDevice(ClimateEntity):
     @property
     def temperature_unit(self) -> str:
         """
-        Return the unit of measurement (Celcius bt default)
+        Return the unit of measurement (Celcius by default)
         """
         return TEMP_CELSIUS
 
@@ -364,8 +366,8 @@ class ThermostatDevice(ClimateEntity):
         - 1: Home
         - 2: Sleep
         - 3: Away
-        - 4: Vacation (not a default home assistant climate state)
-             instead we use the PRESET_ECO to be able to activate this
+        - 4: Vacation (not a default home assistant climate state) instead we
+             use the PRESET_ECO if configured as one of the supported presets
         """
         try:
             return self._valid_presets[self._active_state]
@@ -381,18 +383,17 @@ class ThermostatDevice(ClimateEntity):
         - 1: Programm mode is on (automatically changing presets)
         - 2: Programm mode is on but setpoint/preset is changed until
              the next preset is automatically activated
-        - 8: No official programm mode as according top the Toon API doc
-             this would be state 4. Testing it reveiled it only works when
-             we use an 8. This results in the programm state to return back
-             to it's original state when another preset is selected.
+        - 8: No official programm mode as according to the Toon API doc
+             this would be state 4. Testing reveiled it only works when we
+             use an 8. This results in the programm state to return back to
+             it's original state when another preset is selected.
 
         Toon activeState values
         - 0: Comfort
         - 1: Home
         - 2: Sleep
         - 3: Away
-        - 4: Vacation (not a default home assistant climate state)
-             instead we use the PRESET_ECO to be able to activate this
+        - 4: Vacation (eco)
              
         The preset will only be set if it is part of the SUPPORT_PRESETS list
         """
@@ -444,7 +445,6 @@ class ThermostatDevice(ClimateEntity):
             ),
         )
 
-
     @property
     def hvac_modes(self) -> List[str]:
         """
@@ -458,7 +458,6 @@ class ThermostatDevice(ClimateEntity):
         Return the current operation mode
         """
         return self._hvac_mode
-    
 
     async def async_set_hvac_mode(self, hvac_mode: str) -> None:
         """

--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -12,7 +12,7 @@ climate:
         scan_interval: 10
         min_temp: 6.0
         max_temp: 30.0
-        
+
 logger:
   default: info
   logs:
@@ -62,7 +62,7 @@ try:
     from homeassistant.components.climate import PLATFORM_SCHEMA, ClimateEntity
 except ImportError:
     from homeassistant.components.climate import (
-        PLATFORM_SCHEMA, 
+        PLATFORM_SCHEMA,
         ClimateDevice as ClimateEntity,
     )
 
@@ -77,18 +77,19 @@ PRESET_AWAY:      The device is in away mode
 PRESET_HOME:      The device is in home mode
 PRESET_COMFORT:   The device is in comfort mode
 PRESET_SLEEP:     The device is in Sleep mode
-PRESET_ECO:       The device runs in a continuous energy savings mode. If 
+PRESET_ECO:       The device runs in a continuous energy savings mode. If
                   configured as one of the supported presets this mode can
                   be used to activate the vacation mode
 """
-SUPPORT_PRESETS = [PRESET_AWAY, PRESET_HOME, PRESET_COMFORT, PRESET_SLEEP, PRESET_ECO]
+SUPPORT_PRESETS = [PRESET_AWAY, PRESET_HOME, PRESET_COMFORT, PRESET_SLEEP,
+                   PRESET_ECO]
 
 """
 Supported hvac modes:
 
 - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)
 - HVAC_MODE_AUTO: Follow the configured schedule
-- HVAC_MODE_OFF:  The device runs in a continuous energy savings mode. If 
+- HVAC_MODE_OFF:  The device runs in a continuous energy savings mode. If
                   configured as one of the supported hvac modes this mode
                   can be used to activate the vacation mode
 """
@@ -99,7 +100,7 @@ BASE_URL = "http://{0}:{1}{2}"
 
 """
 The Toon device can be set to a minumum of 6 degrees celsius and a maximum
-of 30 degrees celsius. The below min and max values should not be changed. 
+of 30 degrees celsius. The below min and max values should not be changed.
 """
 DEFAULT_MIN_TEMP = 6.0
 DEFAULT_MAX_TEMP = 30.0
@@ -111,10 +112,13 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
         vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_PORT, default=80): cv.positive_int,
-        vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP): vol.Coerce(float),
-        vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP): vol.Coerce(float),
+        vol.Optional(CONF_MIN_TEMP, default=DEFAULT_MIN_TEMP):
+            vol.Coerce(float),
+        vol.Optional(CONF_MAX_TEMP, default=DEFAULT_MAX_TEMP):
+            vol.Coerce(float),
     }
 )
+
 
 async def async_setup_platform(hass, config, add_devices, discovery_info=None):
     """
@@ -129,6 +133,7 @@ class ThermostatDevice(ClimateEntity):
     """
     Representation of a Toon climate device
     """
+
     def __init__(self, session, config) -> None:
         """
         Initialize the Toon climate device
@@ -137,11 +142,11 @@ class ThermostatDevice(ClimateEntity):
         self._name = config.get(CONF_NAME)
         self._host = config.get(CONF_HOST)
         self._port = config.get(CONF_PORT)
-        self._min_temp = (config.get(CONF_MIN_TEMP) 
-                          if config.get(CONF_MIN_TEMP) >= DEFAULT_MIN_TEMP 
+        self._min_temp = (config.get(CONF_MIN_TEMP)
+                          if config.get(CONF_MIN_TEMP) >= DEFAULT_MIN_TEMP
                           else DEFAULT_MIN_TEMP)
-        self._max_temp = (config.get(CONF_MAX_TEMP) 
-                          if config.get(CONF_MAX_TEMP) <= DEFAULT_MAX_TEMP 
+        self._max_temp = (config.get(CONF_MAX_TEMP)
+                          if config.get(CONF_MAX_TEMP) <= DEFAULT_MAX_TEMP
                           else DEFAULT_MAX_TEMP)
 
         """
@@ -156,28 +161,33 @@ class ThermostatDevice(ClimateEntity):
         self._ot_comm_error = None
         self._program_state = None
         self._hvac_mode = None
-        
+
         """
         Dynamically construct valid preset list
         0: PRESET_COMFORT
         1: PRESET_HOME
         2: PRESET_SLEEP
         3: PRESET_AWAY
-        4: PRESET_ECO     
+        4: PRESET_ECO
         """
         self._valid_presets = {}
-        if (PRESET_COMFORT in SUPPORT_PRESETS): self._valid_presets[0] = PRESET_COMFORT
-        if (PRESET_HOME in SUPPORT_PRESETS): self._valid_presets[1] = PRESET_HOME
-        if (PRESET_SLEEP in SUPPORT_PRESETS): self._valid_presets[2] = PRESET_SLEEP
-        if (PRESET_AWAY in SUPPORT_PRESETS): self._valid_presets[3] = PRESET_AWAY
-        if (PRESET_ECO in SUPPORT_PRESETS): self._valid_presets[4] = PRESET_ECO
-        
-        _LOGGER.info("%s: Supported hvac modes %s. " 
+        if PRESET_COMFORT in SUPPORT_PRESETS:
+            self._valid_presets[0] = PRESET_COMFORT
+        if PRESET_HOME in SUPPORT_PRESETS:
+            self._valid_presets[1] = PRESET_HOME
+        if PRESET_SLEEP in SUPPORT_PRESETS:
+            self._valid_presets[2] = PRESET_SLEEP
+        if PRESET_AWAY in SUPPORT_PRESETS:
+            self._valid_presets[3] = PRESET_AWAY
+        if PRESET_ECO in SUPPORT_PRESETS:
+            self._valid_presets[4] = PRESET_ECO
+
+        _LOGGER.info("%s: Supported hvac modes %s. "
                      "Supported preset modes %s. "
-                     "Temperature can be set between %s°C and %s°C", 
-                      str(self._name), SUPPORT_MODES, 
-                      SUPPORT_PRESETS,
-                      self._min_temp, self._max_temp)
+                     "Temperature can be set between %s°C and %s°C",
+                     self._name, SUPPORT_MODES,
+                     SUPPORT_PRESETS,
+                     self._min_temp, self._max_temp)
 
     @staticmethod
     async def do_api_request(name, session, url):
@@ -190,19 +200,23 @@ class ThermostatDevice(ClimateEntity):
                     url, headers={"Accept-Encoding": "identity"}
                 )
         except aiohttp.ClientError:
-            _LOGGER.error("Cannot poll %s using url: %s", name, url)
+            _LOGGER.error("Cannot poll %s using url: %s",
+                          name, url)
             return None
         except asyncio.TimeoutError:
             _LOGGER.error(
-                "Timeout error occurred while polling %s using url: %s", name, url
+                "Timeout error occurred while polling %s using url: %s",
+                name, url
             )
             return None
 
         try:
             response = await response.json(content_type="text/javascript")
-            _LOGGER.debug("Data received from %s: %s", name, response)
+            _LOGGER.debug("Data received from %s: %s",
+                          name, response)
         except (TypeError, KeyError) as err:
-            _LOGGER.error("Cannot parse data received from %s: %s", name, err)
+            _LOGGER.error("Cannot parse data received from %s: %s",
+                          name, err)
             return None
 
         return response
@@ -219,9 +233,9 @@ class ThermostatDevice(ClimateEntity):
         Update local data with thermostat data (Toon 1 and Toon 2)
         """
         _LOGGER.debug(
-            "%s: request 'getThermostatInfo'", str(self._name),
+            "%s: request 'getThermostatInfo'", self._name,
         )
-        
+
         self._data = await self.do_api_request(
             self._name, self._session,
             BASE_URL.format(
@@ -238,16 +252,16 @@ class ThermostatDevice(ClimateEntity):
             self._current_temperature = int(self._data["currentTemp"]) / 100
             self._ot_comm_error = int(self._data["otCommError"])
             self._program_state = int(self._data["programState"])
-            
-            if (self._active_state == 4):
+
+            if self._active_state == 4:
                 self._hvac_mode = HVAC_MODE_OFF
-            elif (self._program_state == 0):
+            elif self._program_state == 0:
                 self._hvac_mode = HVAC_MODE_HEAT
-            elif (self._program_state == 1) or (self._program_state == 2):
+            elif self._program_state == 1 or self._program_state == 2:
                 self._hvac_mode = HVAC_MODE_AUTO
             else:
                 self._hvac_mode = None
-   
+
     @property
     def supported_features(self) -> int:
         """
@@ -306,24 +320,24 @@ class ThermostatDevice(ClimateEntity):
             return
 
         value = int(target_temperature * 100)
-   
-        if ((target_temperature < self._min_temp) or 
-            (target_temperature > self._max_temp)):
+
+        if (target_temperature < self._min_temp or
+                target_temperature > self._max_temp):
             _LOGGER.warning(
                 "%s: set target temperature to %s°C is not supported. "
-                "The temperature can be set between %s°C and %s°C", 
-                str(self._name), str(target_temperature), 
+                "The temperature can be set between %s°C and %s°C",
+                self._name, str(target_temperature),
                 self._min_temp, self._max_temp)
             return
-   
+
         _LOGGER.info(
             "%s: set target temperature to %s°C",
-            str(self._name), str(target_temperature),
+            self._name, str(target_temperature),
         )
 
         _LOGGER.debug(
             "%s: request 'setSetpoint' with 'Setpoint' value %s",
-            str(self._name), str(value),
+            self._name, str(value),
         )
 
         self._data = await self.do_api_request(
@@ -397,17 +411,17 @@ class ThermostatDevice(ClimateEntity):
         - 2: Sleep
         - 3: Away
         - 4: Vacation (eco)
-             
-        The requested preset will only be set if it is part of the 
+
+        The requested preset will only be set if it is part of the
         defined SUPPORT_PRESETS list
         """
-        if not(preset_mode.lower() in SUPPORT_PRESETS):
+        if not preset_mode.lower() in SUPPORT_PRESETS:
             _LOGGER.warning(
-                "%s: set preset mode to '%s' is not supported. " 
-                "Supported preset modes are %s", 
-                str(self._name), str(preset_mode.lower()), SUPPORT_PRESETS)
+                "%s: set preset mode to '%s' is not supported. "
+                "Supported preset modes are %s",
+                self._name, str(preset_mode.lower()), SUPPORT_PRESETS)
             return None
-        
+
         if preset_mode.lower() == PRESET_COMFORT:
             scheme_temp = 0
             scheme_state = 2
@@ -429,13 +443,13 @@ class ThermostatDevice(ClimateEntity):
 
         _LOGGER.info(
             "%s: set preset mode to '%s'",
-            str(self._name), str(preset_mode.lower()),
-        )    
+            self._name, str(preset_mode.lower()),
+        )
 
         _LOGGER.debug(
             "%s: request 'changeSchemeState' with 'state' value %s "
             "and 'temperatureState' value %s",
-            str(self._name), str(scheme_state),
+            self._name, str(scheme_state),
             str(scheme_temp),
         )
 
@@ -471,25 +485,24 @@ class ThermostatDevice(ClimateEntity):
         - HVAC_MODE_HEAT: Heat to a target temperature (manual mode)
         - HVAC_MODE_AUTO: Follow the configured schedule (schedule mode)
         - HVAC_MODE_OFF: Vacation mode (heat to a target architecture)
-        
-        The requested hvac mode will only be set if it is part of the 
+
+        The requested hvac mode will only be set if it is part of the
         defined SUPPORT_MODES list
         """
-        if not(str(hvac_mode) in SUPPORT_MODES):
+        if hvac_mode not in SUPPORT_MODES:
             _LOGGER.warning(
-                "%s: set hvac mode to '%s' is not supported. " 
-                "Supported hvac modes are %s", 
-                str(self._name), str(hvac_mode), SUPPORT_MODES)
+                "%s: set hvac mode to '%s' is not supported. "
+                "Supported hvac modes are %s",
+                self._name, str(hvac_mode), SUPPORT_MODES)
             return None
-        
-        _LOGGER.info("%s: set hvac mode to '%s'", str(self._name), str(hvac_mode))
-      
+
+        _LOGGER.info("%s: set hvac mode to '%s'", self._name, str(hvac_mode))
+
         if (hvac_mode == HVAC_MODE_HEAT) and (self._active_state == 4):
-            """ Set preset to home when returning from vacation """
             _LOGGER.debug(
                 "%s: request 'changeSchemeState' with 'state' value %s "
                 "and 'temperatureState' value %s",
-                str(self._name), str(0), str(1),
+                self._name, str(0), str(1),
             )
             self._data = await self.do_api_request(
                 self._name, self._session,
@@ -497,14 +510,13 @@ class ThermostatDevice(ClimateEntity):
                     self._host, self._port,
                     "/happ_thermstat?action=changeSchemeState"
                     "&state=0"
-                    "&temperatureState=1",                
+                    "&temperatureState=1",
                 ),
             )
-        elif (hvac_mode == HVAC_MODE_HEAT):
-            """ No preset needs to be defined """
+        elif hvac_mode == HVAC_MODE_HEAT:
             _LOGGER.debug(
                 "%s: request 'changeSchemeState' with 'state' value %s ",
-                str(self._name), str(0)
+                self._name, str(0)
             )
             self._data = await self.do_api_request(
                 self._name, self._session,
@@ -513,12 +525,11 @@ class ThermostatDevice(ClimateEntity):
                     "/happ_thermstat?action=changeSchemeState"
                     "&state=0",
                 ),
-             )   
-        elif (hvac_mode == HVAC_MODE_AUTO):
-            """ No preset needs to be defined """
+             )
+        elif hvac_mode == HVAC_MODE_AUTO:
             _LOGGER.debug(
                 "%s: request 'changeSchemeState' with 'state' value %s ",
-                str(self._name), str(1)
+                self._name, str(1)
             )
             self._data = await self.do_api_request(
                 self._name, self._session,
@@ -528,15 +539,11 @@ class ThermostatDevice(ClimateEntity):
                     "&state=1",
                 ),
             )
-        elif (hvac_mode == HVAC_MODE_OFF):
-            """
-            For vacation mode the state needs to be set to 8 
-            and the temperature preset needs to be set to 4 
-            """
+        elif hvac_mode == HVAC_MODE_OFF:
             _LOGGER.debug(
                 "%s: request 'changeSchemeState' with 'state' value %s "
                 "and 'temperatureState' value %s",
-                str(self._name), str(8), str(4),
+                self._name, str(8), str(4),
             )
             self._data = await self.do_api_request(
                 self._name, self._session,
@@ -544,7 +551,7 @@ class ThermostatDevice(ClimateEntity):
                     self._host, self._port,
                     "/happ_thermstat?action=changeSchemeState"
                     "&state=8"
-                    "&temperatureState=4",                
+                    "&temperatureState=4",
                 ),
             )
 

--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -78,8 +78,8 @@ PRESET_HOME:      The device is in home mode
 PRESET_COMFORT:   The device is in comfort mode
 PRESET_SLEEP:     The device is in Sleep mode
 PRESET_ECO:       The device runs in a continuous energy savings mode. If 
-                  configured as one of the supported presets this This mode
-                  can be used to activate the vacation mode
+                  configured as one of the supported presets this mode can
+                  be used to activate the vacation mode
 """
 SUPPORT_PRESETS = [PRESET_AWAY, PRESET_HOME, PRESET_COMFORT, PRESET_SLEEP, PRESET_ECO]
 
@@ -89,7 +89,7 @@ Supported hvac modes:
 - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)
 - HVAC_MODE_AUTO: Follow the configured schedule
 - HVAC_MODE_OFF:  The device runs in a continuous energy savings mode. If 
-                  configured as one of the supported hvac modes this This mode
+                  configured as one of the supported hvac modes this mode
                   can be used to activate the vacation mode
 """
 SUPPORT_MODES = [HVAC_MODE_HEAT, HVAC_MODE_AUTO]
@@ -382,10 +382,10 @@ class ThermostatDevice(ClimateEntity):
         Set new preset mode (comfort, home, sleep, away, eco)
 
         Toon programState values
-        - 0: Programm mode is off (not automatically changing presets)
+        - 0: Programm mode is off (manually changing presets)
         - 1: Programm mode is on (automatically changing presets)
-        - 2: Programm mode is on but setpoint/preset is changed until
-             the next preset is automatically activated
+        - 2: Programm mode is on but setpoint/preset is only changed until
+             the next scheduled preset is automatically activated
         - 8: No official programm mode as according to the Toon API doc
              this would be state 4. Testing reveiled it only works when we
              use an 8. This results in the programm state to return back to
@@ -398,7 +398,8 @@ class ThermostatDevice(ClimateEntity):
         - 3: Away
         - 4: Vacation (eco)
              
-        The preset will only be set if it is part of the SUPPORT_PRESETS list
+        The requested preset will only be set if it is part of the 
+        defined SUPPORT_PRESETS list
         """
         if not(preset_mode.lower() in SUPPORT_PRESETS):
             _LOGGER.warning(
@@ -467,11 +468,12 @@ class ThermostatDevice(ClimateEntity):
         Set new target hvac mode
 
         Support modes:
-        - HVAC_MODE_HEAT: Heat to a target temperature (schedule off)
-        - HVAC_MODE_AUTO: Follow the configured schedule
+        - HVAC_MODE_HEAT: Heat to a target temperature (manual mode)
+        - HVAC_MODE_AUTO: Follow the configured schedule (schedule mode)
         - HVAC_MODE_OFF: Vacation mode (heat to a target architecture)
         
-        The hvac mode will only be set if it is part of the SUPPORT_MODES list
+        The requested hvac mode will only be set if it is part of the 
+        defined SUPPORT_MODES list
         """
         if not(str(hvac_mode) in SUPPORT_MODES):
             _LOGGER.warning(

--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -45,6 +45,7 @@ from homeassistant.components.climate.const import (
     SUPPORT_PRESET_MODE,
     SUPPORT_TARGET_TEMPERATURE,
 )
+
 from homeassistant.const import (
     ATTR_TEMPERATURE,
     CONF_HOST,
@@ -52,7 +53,9 @@ from homeassistant.const import (
     CONF_PORT,
     TEMP_CELSIUS,
 )
+
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
+
 import homeassistant.helpers.config_validation as cv
 
 try:


### PR DESCRIPTION
Added input validation to ensure requests to change the hvac mode, active preset or target temperature are only accepted and processed if they are within the defined ranges. 

For hvac and preset this is defined in the code itself (SUPPORT_MODES and SUPPORT_PRESETS). 

For the target temperature this is partly defined by the code (the hard limits DEFAULT_MIN_TEMP and DEFAULT_MAX_TEMP) and the limits defined by the home assistant configuration (the configuration parameters "min_temp" and "max_temp"). In case the config is set outside of the hard limits the respective hard limit will prevail above the config parameter.