### PR TITLE
Add unique_id to Toon Climate

### DIFF
--- a/custom_components/toon_climate/climate.py
+++ b/custom_components/toon_climate/climate.py
@@ -148,6 +148,7 @@ class ThermostatDevice(ClimateEntity):
         self._max_temp = (config.get(CONF_MAX_TEMP)
                           if config.get(CONF_MAX_TEMP) <= DEFAULT_MAX_TEMP
                           else DEFAULT_MAX_TEMP)
+        self._attr_unique_id = f"climate_{self._name}_{self._host}"
 
         """
         Standard thermostat data for the first and second edition of Toon


### PR DESCRIPTION
Adding a unique ID to the Toon Climte, to allow for UI changes in HA (i.e. name change, icon change, add to area)

Runs fine locally.

![image](https://user-images.githubusercontent.com/33529490/152323252-d2d07a43-1708-4300-838c-0068d7957cbf.png)
